### PR TITLE
Add setup_aspen_user_debian.sh

### DIFF
--- a/dockerrun.sh
+++ b/dockerrun.sh
@@ -6,6 +6,8 @@
 
 service cron start
 
+./usr/local/aspen-discovery/install/setup_aspen_user_debian.sh
+
 mkdir -p /data/aspen-discovery/test.localhostaspen/covers/{small,large,medium,original}
 
 mkdir -p /usr/local/aspen-discovery/tmp/smarty/compile/


### PR DESCRIPTION
- Add execution of the script to create the aspen user and aspen_apache group since, if they don't exist,Aspen fails to harvest Koha and Solr doesn't index correctly