### PR TITLE
[#10] Mount debug files in the right place

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,9 +1,8 @@
 services:
   aspen-dev-box:
-    image: registry.gitlab.com/aspen-discovery/aspen-dev-box-image/aspen-dev-box:main
     volumes:
-      - '$ASPEN_DOCKER/error_reporting.ini:/etc/php/8.0/apache2/conf.d/error_reporting.ini'
-      - '$ASPEN_DOCKER/xdebug.ini:/etc/php/8.0/apache2/conf.d/xdebug.ini'
+      - '$ASPEN_DOCKER/error_reporting.ini:/etc/php/8.2/apache2/conf.d/error_reporting.ini'
+      - '$ASPEN_DOCKER/xdebug.ini:/etc/php/8.2/apache2/conf.d/20-xdebug.ini'
     environment:
       - WSL_IP
     extra_hosts: 


### PR DESCRIPTION
This patch does two things:

* It makes the override compose file not override the official Docker image, and thus running the same as non-debug mode
* It acknowledges Bookworm ships PHP 8.2 and as such, the `.ini` files belong somewhere else