### PR TITLE
remove the idekey variable to allow other IDE's to debug

### DIFF
--- a/xdebug.ini
+++ b/xdebug.ini
@@ -11,5 +11,4 @@ xdebug.remote_host=host.docker.internal
 xdebug.remote_port=9003
 xdebug.remote_autostart=1
 xdebug.remote_connect_back=1
-xdebug.idekey=VSCODE
 xdebug.max_nesting_level = 1000


### PR DESCRIPTION
This just stops other ide's other than vscode from debugging and does nothing to allow vscode to debug. Only gatekeeps and should be gone.

to test:
check debugging still works on vscode
set up debugging with xdebug with another ide (Tested locally with nvim-dap)
