### PR TITLE
fix: volume mount solr directory in to solr container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
       - SOLR_HOST=solr
     ports:
       - "8084:8084"
+    volumes:
+      - $ASPEN_CLONE/data_dir_setup/solr7:/opt/solr/server/solr/configsets
     deploy:
       endpoint_mode: dnsrr
     networks:


### PR DESCRIPTION
This should prevent schema changes from breaking indexing due to outdated schemas in the solr images, since images are only rebuild on tag of Aspen-discovery repo.